### PR TITLE
Add auto-hide option for Focus on activity

### DIFF
--- a/DynamicNotch/Features/Notch/EventHandlers/NotchFocusEventsHandler.swift
+++ b/DynamicNotch/Features/Notch/EventHandlers/NotchFocusEventsHandler.swift
@@ -5,6 +5,11 @@ final class NotchFocusEventsHandler {
     private let notchViewModel: NotchViewModel
     private let settingsViewModel: SettingsViewModel
 
+    // FocusService re-emits FocusOn on every metadata update while focus stays
+    // active, so in auto-hide mode the notification must only fire on a real
+    // off->on transition or a mode change.
+    private var lastShownFocusMode: FocusModeType?
+
     init(
         notchViewModel: NotchViewModel,
         settingsViewModel: SettingsViewModel
@@ -17,9 +22,23 @@ final class NotchFocusEventsHandler {
         switch event {
         case .FocusOn(let modeType):
             guard settingsViewModel.isLiveActivityEnabled(.focus) else { return }
-            notchViewModel.send(.showLiveActivity(FocusOnNotchContent(settingsViewModel: settingsViewModel, focusModeType: modeType)))
+
+            let content = FocusOnNotchContent(settingsViewModel: settingsViewModel, focusModeType: modeType)
+
+            if settingsViewModel.isTemporaryActivityEnabled(.focusOn) {
+                guard lastShownFocusMode != modeType else { return }
+                lastShownFocusMode = modeType
+                notchViewModel.send(.showTemporaryNotification(content, duration: settingsViewModel.temporaryActivityDuration(for: .focusOn)))
+            } else {
+                lastShownFocusMode = modeType
+                notchViewModel.send(.showLiveActivity(content))
+            }
 
         case .FocusOff(let modeType):
+            lastShownFocusMode = nil
+            if notchViewModel.notchModel.temporaryNotificationContent?.id == NotchContentRegistry.Focus.active.id {
+                notchViewModel.hideTemporaryNotification()
+            }
             notchViewModel.send(.hideLiveActivity(id: NotchContentRegistry.Focus.active.id))
             guard settingsViewModel.isTemporaryActivityEnabled(.focusOff) else { return }
             notchViewModel.send(.showTemporaryNotification(FocusOffNotchContent(settingsViewModel: settingsViewModel, focusModeType: modeType), duration: settingsViewModel.temporaryActivityDuration(for: .focusOff))

--- a/DynamicNotch/Features/Settings/Application/SettingsViewModel.swift
+++ b/DynamicNotch/Features/Settings/Application/SettingsViewModel.swift
@@ -41,6 +41,7 @@ final class SettingsViewModel: ObservableObject, NotchSettingsProviding {
         case bluetooth
         case wifi
         case vpn
+        case focusOn
         case focusOff
         case notchSize
     }
@@ -366,6 +367,8 @@ final class SettingsViewModel: ObservableObject, NotchSettingsProviding {
             return connectivity.isWifiTemporaryActivityEnabled
         case .vpn:
             return connectivity.isVpnTemporaryActivityEnabled
+        case .focusOn:
+            return connectivity.isFocusOnAutoHideEnabled
         case .focusOff:
             return connectivity.isFocusOffTemporaryActivityEnabled
         case .notchSize:
@@ -387,6 +390,8 @@ final class SettingsViewModel: ObservableObject, NotchSettingsProviding {
             return scaledTemporaryActivityDuration(TimeInterval(connectivity.wifiTemporaryActivityDuration))
         case .vpn:
             return scaledTemporaryActivityDuration(TimeInterval(connectivity.vpnTemporaryActivityDuration))
+        case .focusOn:
+            return scaledTemporaryActivityDuration(TimeInterval(connectivity.focusOnTemporaryActivityDuration))
         case .focusOff:
             return scaledTemporaryActivityDuration(TimeInterval(connectivity.focusOffTemporaryActivityDuration))
         case .notchSize:

--- a/DynamicNotch/Features/Settings/Connectivity/FocusSettingsView.swift
+++ b/DynamicNotch/Features/Settings/Connectivity/FocusSettingsView.swift
@@ -30,12 +30,28 @@ struct FocusSettingsView: View {
                 isOn: $connectivitySettings.isFocusLiveActivityEnabled,
                 accessibilityIdentifier: "settings.activities.live.focus"
             )
-            
+
             Divider()
                 .opacity(0.6)
                 .padding(.leading, 43)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .trailing)
-            
+
+            SettingsToggleRow(
+                title: "Hide Focus activity automatically",
+                description: "Show the Focus activity briefly when Focus turns on instead of keeping it visible the whole time.",
+                systemImage: "moon.zzz.fill",
+                color: .indigo,
+                isOn: $connectivitySettings.isFocusOnAutoHideEnabled,
+                accessibilityIdentifier: "settings.activities.live.focus.autoHide"
+            )
+            .disabled(!connectivitySettings.isFocusLiveActivityEnabled)
+            .opacity(connectivitySettings.isFocusLiveActivityEnabled ? 1 : 0.5)
+
+            Divider()
+                .opacity(0.6)
+                .padding(.leading, 43)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .trailing)
+
             SettingsToggleRow(
                 title: "Focus off activity",
                 description: "Show a short notification when Focus mode turns off.",
@@ -49,6 +65,27 @@ struct FocusSettingsView: View {
     
     private var focusDuration: some View {
         SettingsCard(title: "Focus duration") {
+            SettingsSliderRow(
+                title: "Focus on duration",
+                description: "Choose how long the Focus on notification stays visible.",
+                range: temporaryActivityDurationRange,
+                step: 1,
+                fractionLength: 0,
+                suffix: "s",
+                accessibilityIdentifier: "settings.activities.temporary.focusOn.duration",
+                value: Binding(
+                    get: { Double(connectivitySettings.focusOnTemporaryActivityDuration) },
+                    set: { connectivitySettings.focusOnTemporaryActivityDuration = Int($0.rounded()) }
+                )
+            )
+            .disabled(!connectivitySettings.isFocusOnAutoHideEnabled || !connectivitySettings.isFocusLiveActivityEnabled)
+            .opacity(connectivitySettings.isFocusOnAutoHideEnabled && connectivitySettings.isFocusLiveActivityEnabled ? 1 : 0.5)
+
+            Divider()
+                .opacity(0.6)
+                .padding(.leading, 43)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .trailing)
+
             SettingsSliderRow(
                 title: "Focus off duration",
                 description: "Choose how long the Focus off notification stays visible.",

--- a/DynamicNotch/Features/Settings/Shared/Stores/ConnectivitySettingsStore.swift
+++ b/DynamicNotch/Features/Settings/Shared/Stores/ConnectivitySettingsStore.swift
@@ -15,6 +15,24 @@ final class ConnectivitySettingsStore: SettingsStoreBase {
         }
     }
 
+    @Published var isFocusOnAutoHideEnabled: Bool {
+        didSet {
+            persist(isFocusOnAutoHideEnabled, for: GeneralSettingsStorage.Keys.focusOnAutoHideEnabled)
+        }
+    }
+
+    @Published var focusOnTemporaryActivityDuration: Int {
+        didSet {
+            let clampedValue = Self.clampTemporaryActivityDuration(focusOnTemporaryActivityDuration)
+            if clampedValue != focusOnTemporaryActivityDuration {
+                focusOnTemporaryActivityDuration = clampedValue
+                return
+            }
+
+            persist(focusOnTemporaryActivityDuration, for: GeneralSettingsStorage.Keys.focusOnTemporaryActivityDuration)
+        }
+    }
+
     @Published var focusAppearanceStyle: FocusAppearanceStyle {
         didSet {
             persist(focusAppearanceStyle.rawValue, for: GeneralSettingsStorage.Keys.focusAppearanceStyle)
@@ -160,6 +178,11 @@ final class ConnectivitySettingsStore: SettingsStoreBase {
         defaults.register(defaults: GeneralSettingsStorage.defaultValues)
         self.isHotspotLiveActivityEnabled = defaults.bool(forKey: GeneralSettingsStorage.Keys.hotspotLiveActivityEnabled)
         self.isFocusLiveActivityEnabled = defaults.bool(forKey: GeneralSettingsStorage.Keys.focusLiveActivityEnabled)
+        self.isFocusOnAutoHideEnabled = defaults.bool(forKey: GeneralSettingsStorage.Keys.focusOnAutoHideEnabled)
+        self.focusOnTemporaryActivityDuration = Self.clampTemporaryActivityDuration(
+            defaults.object(forKey: GeneralSettingsStorage.Keys.focusOnTemporaryActivityDuration) as? Int ??
+            Self.defaultTemporaryActivityDuration(for: GeneralSettingsStorage.Keys.focusOnTemporaryActivityDuration)
+        )
         self.focusAppearanceStyle = FocusAppearanceStyle.resolved(
             defaults.string(forKey: GeneralSettingsStorage.Keys.focusAppearanceStyle)
         )
@@ -243,6 +266,10 @@ final class ConnectivitySettingsStore: SettingsStoreBase {
 
     func resetFocus() {
         isFocusLiveActivityEnabled = defaultBool(for: GeneralSettingsStorage.Keys.focusLiveActivityEnabled)
+        isFocusOnAutoHideEnabled = defaultBool(for: GeneralSettingsStorage.Keys.focusOnAutoHideEnabled)
+        focusOnTemporaryActivityDuration = Self.clampTemporaryActivityDuration(
+            defaultInt(for: GeneralSettingsStorage.Keys.focusOnTemporaryActivityDuration)
+        )
         focusAppearanceStyle = FocusAppearanceStyle.resolved(
             defaultString(for: GeneralSettingsStorage.Keys.focusAppearanceStyle)
         )

--- a/DynamicNotch/Features/Settings/Shared/Stores/GeneralSettingsStorage.swift
+++ b/DynamicNotch/Features/Settings/Shared/Stores/GeneralSettingsStorage.swift
@@ -39,6 +39,8 @@ enum GeneralSettingsStorage {
         static let hudColoredStrokeEnabled = "settings.hud.coloredStroke"
         static let hotspotLiveActivityEnabled = "settings.live.hotspot"
         static let focusLiveActivityEnabled = "settings.live.focus"
+        static let focusOnAutoHideEnabled = "settings.live.focus.autoHide"
+        static let focusOnTemporaryActivityDuration = "settings.temporary.focusOn.duration"
         static let focusAppearanceStyle = "settings.focus.appearanceStyle"
         static let nowPlayingLiveActivityEnabled = "settings.live.nowPlaying"
         static let closeAtFocusLiveActivityEnabled = "settings.nowPlaying.closeAtFocus"
@@ -160,6 +162,8 @@ enum GeneralSettingsStorage {
         Keys.hudColoredStrokeEnabled: false,
         Keys.hotspotLiveActivityEnabled: true,
         Keys.focusLiveActivityEnabled: true,
+        Keys.focusOnAutoHideEnabled: false,
+        Keys.focusOnTemporaryActivityDuration: 3,
         Keys.focusAppearanceStyle: FocusAppearanceStyle.iconsOnly.rawValue,
         Keys.nowPlayingLiveActivityEnabled: true,
         Keys.closeAtFocusLiveActivityEnabled: true,

--- a/DynamicNotch/Resources/Localization/Localizable.xcstrings
+++ b/DynamicNotch/Resources/Localization/Localizable.xcstrings
@@ -2522,6 +2522,34 @@
         }
       }
     },
+    "Choose how long the Focus on notification stays visible." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose how long the Focus on notification stays visible."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elija cuánto tiempo permanecerá visible la notificación de enfoque activado."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выберите, как долго показывается уведомление Focus On."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择焦点开启通知保持可见的时间。"
+          }
+        }
+      }
+    },
     "Choose how long the full battery notification stays visible." : {
       "localizations" : {
         "en" : {
@@ -6045,6 +6073,34 @@
         }
       }
     },
+    "Focus on duration" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Focus on duration"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Duración del enfoque activado"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Длительность Focus On"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "焦点开启持续时间"
+          }
+        }
+      }
+    },
     "Focus style" : {
       "localizations" : {
         "en" : {
@@ -6468,6 +6524,34 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "隐藏收藏"
+          }
+        }
+      }
+    },
+    "Hide Focus activity automatically" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hide Focus activity automatically"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ocultar la actividad de enfoque automáticamente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автоматически скрывать активность Focus"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动隐藏专注活动"
           }
         }
       }
@@ -17176,6 +17260,34 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "放下文件进行转换后显示 File Converter 实时活动。"
+          }
+        }
+      }
+    },
+    "Show the Focus activity briefly when Focus turns on instead of keeping it visible the whole time." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show the Focus activity briefly when Focus turns on instead of keeping it visible the whole time."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Muestra brevemente la actividad de enfoque al activarse, en lugar de mantenerla visible todo el tiempo."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Кратко показывать активность Focus при включении вместо постоянного отображения."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "专注模式开启时短暂显示活动，而不是一直保持可见。"
           }
         }
       }


### PR DESCRIPTION
Add a "Hide Focus activity automatically" toggle and a "Focus on duration" slider. When enabled, the Focus on indicator is shown as a temporary notification instead of a persistent live activity.