### PR TITLE
Fix incorrect alt text for gallery images in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ Then run the `DynamicNotch` scheme from Xcode. Swift Package Manager dependencie
 
 <table align="center">
   <tr>
-    <td><img src="assets/readme/NoInternet.png" alt="Player" width="100%" /></td>
-    <td><img src="assets/readme/Tray.png" alt="Lock Screen" width="100%" /></td>
+    <td><img src="assets/readme/NoInternet.png" alt="No Internet" width="100%" /></td>
+    <td><img src="assets/readme/Tray.png" alt="Tray" width="100%" /></td>
     <td><img src="assets/readme/Timer.png" alt="Timer" width="100%" /></td>
   </tr>
   <tr>
@@ -113,9 +113,9 @@ Then run the `DynamicNotch` scheme from Xcode. Swift Package Manager dependencie
     <td><img src="assets/readme/VolumeHud.png" alt="Volume HUD" width="100%" /></td>
   </tr>
   <tr>
-    <td><img src="assets/readme/Hotspot.png" alt="Bluetooth" width="100%" /></td>
-    <td><img src="assets/readme/Downloads.png" alt="VPN Connection" width="100%" /></td>
-    <td><img src="assets/readme/FocusMode.png" alt="Volume HUD" width="100%" /></td>
+    <td><img src="assets/readme/Hotspot.png" alt="Hotspot" width="100%" /></td>
+    <td><img src="assets/readme/Downloads.png" alt="Downloads" width="100%" /></td>
+    <td><img src="assets/readme/FocusMode.png" alt="Focus Mode" width="100%" /></td>
   </tr>
 </table>
 


### PR DESCRIPTION
## Description

Several images in the README gallery section had incorrect alt attributes due to copy-paste errors. The alt text did not match the actual image being displayed.

## Changes

Fixed the alt attributes for the following gallery images:
- NoInternet.png: changed from "Player" to "No Internet"
- Tray.png: changed from "Lock Screen" to "Tray"
- Hotspot.png: changed from "Bluetooth" to "Hotspot"
- Downloads.png: changed from "VPN Connection" to "Downloads"
- FocusMode.png: changed from "Volume HUD" to "Focus Mode"

These corrections improve accessibility for screen readers and make the README more accurate.
