### PR TITLE
Fix NotchView argument order so the project compiles

### DIFF
--- a/DynamicNotch/Application/AppDelegate/AppDelegate+Window.swift
+++ b/DynamicNotch/Application/AppDelegate/AppDelegate+Window.swift
@@ -23,7 +23,6 @@ extension AppDelegate {
 
         let hostingView = NotchHostingView(
             rootView: NotchView(
-                notchViewModel: notchViewModel,
                 notchEventCoordinator: notchEventCoordinator,
                 powerViewModel: powerViewModel,
                 bluetoothViewModel: bluetoothViewModel,
@@ -31,14 +30,15 @@ extension AppDelegate {
                 vpnViewModel: vpnViewModel,
                 downloadViewModel: downloadViewModel,
                 focusViewModel: focusViewModel,
-                airDropViewModel: airDropViewModel,
-                airDropController: airDropController,
-                settingsViewModel: settingsViewModel,
                 nowPlayingViewModel: nowPlayingViewModel,
                 timerViewModel: timerViewModel,
                 screenRecordingViewModel: screenRecordingViewModel,
                 lockScreenManager: lockScreenManager,
-                homePageViewModel: homePageViewModel
+                homePageViewModel: homePageViewModel,
+                notchViewModel: notchViewModel,
+                airDropViewModel: airDropViewModel,
+                airDropController: airDropController,
+                settingsViewModel: settingsViewModel
             )
         )
 


### PR DESCRIPTION
## Problem

`main` does not compile. `NotchView`'s memberwise initializer follows its property
declaration order, but `createNotchWindow()` passes the view models in a different
order:

```
error: incorrect argument labels in call
  (have 'notchViewModel:notchEventCoordinator:powerViewModel:...')
  (expected 'notchEventCoordinator:powerViewModel:bluetoothViewModel:...')
```

The mismatch appears to date from `6d082f2 Refactor notch UI into reusable components`,
which reordered the properties on `NotchView` without updating this call site.

## Fix

Reorder the arguments at the call site to match the declaration order. Pure
reordering — same values, same labels, no behavioural change. The compiler
verifies correctness.

## Testing

- `xcodebuild ... build` → **BUILD SUCCEEDED** (fails on `main` without this)
- `xcodebuild test -scheme DynamicNotch -only-testing:DynamicNotchTests` → 131 passed

### Pre-existing test failures

Five unit tests fail both with and without this change (verified on `main` in a clean
worktree with only this fix applied), so they are unrelated to it:

- `NotchEventCoordinatorIntegrationTests.testChargerNotificationShowOnLockScreen`
- `NotchEventCoordinatorIntegrationTests.testDisabledDragAndDropSuppressesLiveActivity`
- `NotchEventCoordinatorIntegrationTests.testVolumeHUDShowOnLockScreen`
- `NotchViewModelIntegrationTests.testUpdateDimensionsUsesSelectedDisplayMetrics`
- `NotchViewModelIntegrationTests.testUpdateDimensionsUsesSpecificDisplayMetrics`

Root cause not investigated; out of scope here.

## Checklist

- [x] Compiles without errors or warnings
- [ ] All unit and UI tests pass — 5 pre-existing failures listed above; UI tests (`DynamicNotchUI` scheme) pass
- [x] Follows formatting and style guidelines
- [x] Rebased onto latest `main`
- [x] Clear description of the problem and fix
- [ ] Screenshots — not applicable, no UI change