### PR TITLE
Fix persistence keys for battery sound settings

### DIFF
--- a/DynamicNotch/Features/Settings/Shared/Stores/BatterySettingsStore.swift
+++ b/DynamicNotch/Features/Settings/Shared/Stores/BatterySettingsStore.swift
@@ -93,13 +93,13 @@ final class BatterySettingsStore: SettingsStoreBase {
 
     @Published var fullBatterySound: Bool {
         didSet {
-            persist(fullBatterySound, for: GeneralSettingsStorage.Keys.fullPowerNotificationStyle)
+                        persist(fullBatterySound, for: GeneralSettingsStorage.Keys.fullBatterySound)
         }
     }
     
     @Published var lowBatterySound: Bool {
         didSet {
-            persist(lowBatterySound, for: GeneralSettingsStorage.Keys.fullPowerNotificationStyle)
+                        persist(lowBatterySound, for: GeneralSettingsStorage.Keys.lowBatterySound)
         }
     }
     


### PR DESCRIPTION
Both `fullBatterySound` and `lowBatterySound` were persisted to `Keys.fullPowerNotificationStyle` instead of their own keys (`Keys.fullBatterySound` / `Keys.lowBatterySound`).

As a result:
- the sound toggles were never actually saved and reset to defaults on every launch;
- toggling a sound overwrote `settings.temporary.fullPower.style` with a Bool (`0`), which also broke persistence of the Full Battery style.

Reading in `init` already uses the correct keys (`defaults.bool(forKey: Keys.lowBatterySound)` etc.), so fixing the write side is enough.

Verified on 1.6.1: manually writing the correct keys via `defaults write` makes the settings survive restarts.