### PR TITLE
Add one-time cleanup for corrupted fullPower style value

### DIFF
--- a/DynamicNotch/Features/Settings/Shared/Stores/BatterySettingsStore.swift
+++ b/DynamicNotch/Features/Settings/Shared/Stores/BatterySettingsStore.swift
@@ -124,6 +124,7 @@ final class BatterySettingsStore: SettingsStoreBase {
     override init(defaults: UserDefaults) {
         defaults.register(defaults: GeneralSettingsStorage.defaultValues)
         Self.migrateLegacyDefaultStrokeIfNeeded(defaults: defaults)
+        Self.migrateCorruptedFullPowerStyleIfNeeded(defaults: defaults)
         self.lowBatterySound = defaults.bool(forKey: GeneralSettingsStorage.Keys.lowBatterySound)
         self.fullBatterySound = defaults.bool(forKey: GeneralSettingsStorage.Keys.fullBatterySound)
         self.isChargerTemporaryActivityEnabled = defaults.bool(forKey: GeneralSettingsStorage.Keys.chargerTemporaryActivityEnabled)
@@ -211,5 +212,14 @@ final class BatterySettingsStore: SettingsStoreBase {
         }
 
         defaults.removeObject(forKey: legacyBatteryDefaultStrokeKey)
+    }
+    
+    private static func migrateCorruptedFullPowerStyleIfNeeded(defaults: UserDefaults) {
+        // Older versions wrote the battery sound Bool into this key,
+        // leaving a number where a BatteryNotificationStyle raw value is expected.
+        let key = GeneralSettingsStorage.Keys.fullPowerNotificationStyle
+        if let stored = defaults.object(forKey: key), !(stored is String) {
+            defaults.removeObject(forKey: key)
+        }
     }
 }


### PR DESCRIPTION
Added a one-time cleanup migration in the second commit: older versions wrote the sound toggle Bool into `settings.temporary.fullPower.style`, so existing users still have a corrupted (non-string) value there even after the write path is fixed. The migration removes it so the registered default applies; healthy string values and absent keys are untouched.
<img width="662" height="584" alt="Screenshot_1787329780" src="https://github.com/user-attachments/assets/b9b86450-7e32-4716-86be-bdf4bc9fb648" />


Verified the migration logic against real UserDefaults with a standalone test: corrupted Bool → removed, falls back to registered default; healthy string → untouched; absent key → no-op.