### PR TITLE
Pass media keys held with shortcut modifiers through the tap

### DIFF
--- a/DynamicNotch/Core/Services/HUD/SystemMediaKeyTap.swift
+++ b/DynamicNotch/Core/Services/HUD/SystemMediaKeyTap.swift
@@ -6,13 +6,19 @@ import Foundation
 import ApplicationServices
 #endif
 
-private enum MediaKeyCode {
+enum MediaKeyCode {
     static let systemDefinedEventType: UInt32 = 14
     static let volumeUp: Int32 = 0
     static let volumeDown: Int32 = 1
     static let brightnessUp: Int32 = 2
     static let brightnessDown: Int32 = 3
     static let mute: Int32 = 7
+}
+
+private enum MediaKeyModifiers {
+    static let considered: NSEvent.ModifierFlags = [.command, .control, .option, .shift]
+    static let quietVolume: NSEvent.ModifierFlags = [.shift]
+    static let fineAdjustment: NSEvent.ModifierFlags = [.option, .shift]
 }
 
 enum MediaKeyDirection {
@@ -36,6 +42,31 @@ struct SystemMediaKeyTapConfiguration {
 
     var interceptsAnyMediaKey: Bool {
         interceptVolume || interceptBrightness
+    }
+
+    func intercepts(keyCode: Int32, modifiers: NSEvent.ModifierFlags) -> Bool {
+        guard interceptsKeyCode(keyCode) else {
+            return false
+        }
+
+        let activeModifiers = modifiers.intersection(MediaKeyModifiers.considered)
+        return activeModifiers.isEmpty
+            || activeModifiers == MediaKeyModifiers.quietVolume
+            || activeModifiers == MediaKeyModifiers.fineAdjustment
+    }
+
+    private func interceptsKeyCode(_ keyCode: Int32) -> Bool {
+        switch keyCode {
+        case MediaKeyCode.volumeUp,
+             MediaKeyCode.volumeDown,
+             MediaKeyCode.mute:
+            return interceptVolume
+        case MediaKeyCode.brightnessUp,
+             MediaKeyCode.brightnessDown:
+            return interceptBrightness
+        default:
+            return false
+        }
     }
 }
 
@@ -72,6 +103,7 @@ final class SystemMediaKeyTap {
     private var runLoopSource: CFRunLoopSource?
     private var hasRequestedAccessibilityPrompt = false
     private var isTapEnabled = false
+    private var interceptedKeyCodes: Set<Int32> = []
 
     private var systemDefinedEvent: CGEventType? {
         CGEventType(rawValue: MediaKeyCode.systemDefinedEventType)
@@ -138,9 +170,10 @@ final class SystemMediaKeyTap {
         eventTap = nil
         runLoopSource = nil
         isTapEnabled = false
+        interceptedKeyCodes.removeAll()
     }
 
-    private func handleEvent(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+    func handleEvent(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
             if let eventTap, configuration.interceptsAnyMediaKey {
                 CGEvent.tapEnable(tap: eventTap, enable: true)
@@ -160,71 +193,47 @@ final class SystemMediaKeyTap {
         let keyCode = Int32((data1 & 0xFFFF0000) >> 16)
         let keyFlags = data1 & 0x0000FFFF
         let isKeyDown = ((keyFlags & 0xFF00) >> 8) == 0xA
+        let modifiers = nsEvent.modifierFlags
 
-        if !isKeyDown {
-            return shouldHandleKeyCode(keyCode) ? nil : Unmanaged.passUnretained(event)
+        guard isKeyDown else {
+            return interceptedKeyCodes.remove(keyCode) == nil ? Unmanaged.passUnretained(event) : nil
         }
 
+        guard configuration.intercepts(keyCode: keyCode, modifiers: modifiers) else {
+            interceptedKeyCodes.remove(keyCode)
+            return Unmanaged.passUnretained(event)
+        }
+
+        interceptedKeyCodes.insert(keyCode)
         let granularity = granularity(for: nsEvent)
 
         switch keyCode {
         case MediaKeyCode.volumeUp:
-            guard configuration.interceptVolume else {
-                return Unmanaged.passUnretained(event)
-            }
-            delegate?.mediaKeyTap(self, didReceiveVolumeCommand: .increase, granularity: granularity, modifiers: nsEvent.modifierFlags)
-            return nil
+            delegate?.mediaKeyTap(self, didReceiveVolumeCommand: .increase, granularity: granularity, modifiers: modifiers)
 
         case MediaKeyCode.volumeDown:
-            guard configuration.interceptVolume else {
-                return Unmanaged.passUnretained(event)
-            }
-            delegate?.mediaKeyTap(self, didReceiveVolumeCommand: .decrease, granularity: granularity, modifiers: nsEvent.modifierFlags)
-            return nil
+            delegate?.mediaKeyTap(self, didReceiveVolumeCommand: .decrease, granularity: granularity, modifiers: modifiers)
 
         case MediaKeyCode.mute:
-            guard configuration.interceptVolume else {
-                return Unmanaged.passUnretained(event)
-            }
             delegate?.mediaKeyTapDidToggleMute(self)
-            return nil
 
         case MediaKeyCode.brightnessUp:
-            guard configuration.interceptBrightness else {
-                return Unmanaged.passUnretained(event)
-            }
             // Consume the brightness key. On macOS 26 the only way to hide the
             // system OSD (drawn by MenuBarAgent, unkillable) is to swallow the key
             // so the OS never shows it — the same way volume keys are handled. The
             // trade-off is discrete steps, since the smooth hardware ramp is only
             // available when the key isn't consumed.
-            delegate?.mediaKeyTap(self, didReceiveBrightnessCommand: .increase, granularity: granularity, modifiers: nsEvent.modifierFlags)
-            return nil
+            delegate?.mediaKeyTap(self, didReceiveBrightnessCommand: .increase, granularity: granularity, modifiers: modifiers)
 
         case MediaKeyCode.brightnessDown:
-            guard configuration.interceptBrightness else {
-                return Unmanaged.passUnretained(event)
-            }
-            delegate?.mediaKeyTap(self, didReceiveBrightnessCommand: .decrease, granularity: granularity, modifiers: nsEvent.modifierFlags)
-            return nil
+            delegate?.mediaKeyTap(self, didReceiveBrightnessCommand: .decrease, granularity: granularity, modifiers: modifiers)
 
         default:
+            interceptedKeyCodes.remove(keyCode)
             return Unmanaged.passUnretained(event)
         }
-    }
 
-    private func shouldHandleKeyCode(_ keyCode: Int32) -> Bool {
-        switch keyCode {
-        case MediaKeyCode.volumeUp,
-             MediaKeyCode.volumeDown,
-             MediaKeyCode.mute:
-            return configuration.interceptVolume
-        case MediaKeyCode.brightnessUp,
-             MediaKeyCode.brightnessDown:
-            return configuration.interceptBrightness
-        default:
-            return false
-        }
+        return nil
     }
 
     private func granularity(for event: NSEvent) -> MediaKeyGranularity {
@@ -244,6 +253,10 @@ final class SystemMediaKeyTap {
 
         CGEvent.tapEnable(tap: eventTap, enable: shouldEnableTap)
         isTapEnabled = shouldEnableTap
+
+        if !shouldEnableTap {
+            interceptedKeyCodes.removeAll()
+        }
     }
 
     deinit {

--- a/DynamicNotchTests/Features/HUD/SystemMediaKeyTapConfigurationTests.swift
+++ b/DynamicNotchTests/Features/HUD/SystemMediaKeyTapConfigurationTests.swift
@@ -1,0 +1,59 @@
+import AppKit
+import XCTest
+@testable import DynamicNotch
+
+final class SystemMediaKeyTapConfigurationTests: XCTestCase {
+    private let configuration = SystemMediaKeyTapConfiguration(
+        interceptVolume: true,
+        interceptBrightness: true
+    )
+
+    func testInterceptsBrightnessKeyWithoutModifiers() {
+        XCTAssertTrue(configuration.intercepts(keyCode: MediaKeyCode.brightnessDown, modifiers: []))
+        XCTAssertTrue(configuration.intercepts(keyCode: MediaKeyCode.brightnessUp, modifiers: []))
+    }
+
+    func testInterceptsBrightnessKeyWithFineAdjustmentModifiers() {
+        XCTAssertTrue(
+            configuration.intercepts(keyCode: MediaKeyCode.brightnessUp, modifiers: [.option, .shift])
+        )
+    }
+
+    func testInterceptsVolumeKeyWithShift() {
+        XCTAssertTrue(configuration.intercepts(keyCode: MediaKeyCode.volumeUp, modifiers: [.shift]))
+    }
+
+    func testIgnoresKeyboardStateModifiers() {
+        XCTAssertTrue(
+            configuration.intercepts(keyCode: MediaKeyCode.brightnessUp, modifiers: [.function, .capsLock, .numericPad])
+        )
+    }
+
+    func testSkipsBrightnessKeyHeldWithCommand() {
+        XCTAssertFalse(configuration.intercepts(keyCode: MediaKeyCode.brightnessDown, modifiers: [.command]))
+        XCTAssertFalse(
+            configuration.intercepts(keyCode: MediaKeyCode.brightnessDown, modifiers: [.command, .shift])
+        )
+    }
+
+    func testSkipsBrightnessKeyHeldWithControl() {
+        XCTAssertFalse(configuration.intercepts(keyCode: MediaKeyCode.brightnessUp, modifiers: [.control]))
+    }
+
+    func testSkipsMediaKeyHeldWithOptionAlone() {
+        XCTAssertFalse(configuration.intercepts(keyCode: MediaKeyCode.brightnessUp, modifiers: [.option]))
+        XCTAssertFalse(configuration.intercepts(keyCode: MediaKeyCode.volumeUp, modifiers: [.option]))
+    }
+
+    func testSkipsDisabledMediaKeys() {
+        let brightnessOnly = SystemMediaKeyTapConfiguration(interceptVolume: false, interceptBrightness: true)
+
+        XCTAssertFalse(brightnessOnly.intercepts(keyCode: MediaKeyCode.volumeDown, modifiers: []))
+        XCTAssertFalse(brightnessOnly.intercepts(keyCode: MediaKeyCode.mute, modifiers: []))
+        XCTAssertTrue(brightnessOnly.intercepts(keyCode: MediaKeyCode.brightnessDown, modifiers: []))
+    }
+
+    func testSkipsUnknownKeyCode() {
+        XCTAssertFalse(configuration.intercepts(keyCode: 16, modifiers: []))
+    }
+}

--- a/DynamicNotchTests/Features/HUD/SystemMediaKeyTapTests.swift
+++ b/DynamicNotchTests/Features/HUD/SystemMediaKeyTapTests.swift
@@ -1,0 +1,128 @@
+import AppKit
+import CoreGraphics
+import XCTest
+@testable import DynamicNotch
+
+final class SystemMediaKeyTapTests: XCTestCase {
+    private var tap: SystemMediaKeyTap!
+    private var delegate: MediaKeyTapDelegateSpy!
+
+    override func setUp() {
+        super.setUp()
+        tap = SystemMediaKeyTap()
+        delegate = MediaKeyTapDelegateSpy()
+        tap.delegate = delegate
+        tap.configuration = SystemMediaKeyTapConfiguration(interceptVolume: true, interceptBrightness: true)
+    }
+
+    override func tearDown() {
+        tap = nil
+        delegate = nil
+        super.tearDown()
+    }
+
+    func testConsumesBrightnessKeyPressedAlone() {
+        let result = handle(keyCode: MediaKeyCode.brightnessUp, isKeyDown: true, modifiers: [])
+
+        XCTAssertNil(result)
+        XCTAssertEqual(delegate.brightnessCommands, [.increase])
+    }
+
+    func testPassesBrightnessKeyHeldWithCommandThrough() {
+        let result = handle(keyCode: MediaKeyCode.brightnessDown, isKeyDown: true, modifiers: [.command])
+
+        XCTAssertNotNil(result)
+        XCTAssertTrue(delegate.brightnessCommands.isEmpty)
+    }
+
+    func testPassesBrightnessKeyHeldWithOptionThrough() {
+        let result = handle(keyCode: MediaKeyCode.brightnessUp, isKeyDown: true, modifiers: [.option])
+
+        XCTAssertNotNil(result)
+        XCTAssertTrue(delegate.brightnessCommands.isEmpty)
+    }
+
+    func testConsumesBrightnessKeyHeldWithOptionAndShift() {
+        let result = handle(keyCode: MediaKeyCode.brightnessUp, isKeyDown: true, modifiers: [.option, .shift])
+
+        XCTAssertNil(result)
+        XCTAssertEqual(delegate.brightnessGranularities, [.fine])
+    }
+
+    func testConsumesKeyUpOfConsumedKeyDown() {
+        _ = handle(keyCode: MediaKeyCode.brightnessUp, isKeyDown: true, modifiers: [])
+
+        XCTAssertNil(handle(keyCode: MediaKeyCode.brightnessUp, isKeyDown: false, modifiers: []))
+    }
+
+    func testPassesKeyUpThroughAfterPassedThroughKeyDown() {
+        _ = handle(keyCode: MediaKeyCode.brightnessDown, isKeyDown: true, modifiers: [.command])
+
+        XCTAssertNotNil(handle(keyCode: MediaKeyCode.brightnessDown, isKeyDown: false, modifiers: []))
+    }
+
+    private func handle(
+        keyCode: Int32,
+        isKeyDown: Bool,
+        modifiers: NSEvent.ModifierFlags
+    ) -> Unmanaged<CGEvent>? {
+        guard let type = CGEventType(rawValue: MediaKeyCode.systemDefinedEventType),
+              let event = mediaKeyEvent(keyCode: keyCode, isKeyDown: isKeyDown, modifiers: modifiers) else {
+            XCTFail("Failed to build a system-defined media key event")
+            return nil
+        }
+
+        return tap.handleEvent(type: type, event: event)
+    }
+
+    private func mediaKeyEvent(
+        keyCode: Int32,
+        isKeyDown: Bool,
+        modifiers: NSEvent.ModifierFlags
+    ) -> CGEvent? {
+        let keyState = isKeyDown ? 0xA : 0xB
+        let event = NSEvent.otherEvent(
+            with: .systemDefined,
+            location: .zero,
+            modifierFlags: modifiers,
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            subtype: 8,
+            data1: (Int(keyCode) << 16) | (keyState << 8),
+            data2: -1
+        )
+
+        return event?.cgEvent
+    }
+}
+
+private final class MediaKeyTapDelegateSpy: SystemMediaKeyTapDelegate {
+    private(set) var volumeCommands: [MediaKeyDirection] = []
+    private(set) var brightnessCommands: [MediaKeyDirection] = []
+    private(set) var brightnessGranularities: [MediaKeyGranularity] = []
+    private(set) var muteToggleCount = 0
+
+    func mediaKeyTap(
+        _ tap: SystemMediaKeyTap,
+        didReceiveVolumeCommand direction: MediaKeyDirection,
+        granularity: MediaKeyGranularity,
+        modifiers: NSEvent.ModifierFlags
+    ) {
+        volumeCommands.append(direction)
+    }
+
+    func mediaKeyTapDidToggleMute(_ tap: SystemMediaKeyTap) {
+        muteToggleCount += 1
+    }
+
+    func mediaKeyTap(
+        _ tap: SystemMediaKeyTap,
+        didReceiveBrightnessCommand direction: MediaKeyDirection,
+        granularity: MediaKeyGranularity,
+        modifiers: NSEvent.ModifierFlags
+    ) {
+        brightnessCommands.append(direction)
+        brightnessGranularities.append(granularity)
+    }
+}


### PR DESCRIPTION
## Problem

The media key tap consumed every system-defined brightness/volume event regardless of the
modifiers held, so shortcuts built on F1/F2 never reached macOS or the front app: `Cmd+F1`,
`Ctrl+F2` and `Option+F2` (System Settings → Displays) all just changed brightness.

## Fix

I asked Claude to fix this bug.

Interception now depends on the modifiers as well as the key code. Consumed: no modifiers,
`Shift` (volume without the feedback click) and `Option+Shift` (fine step). Everything else
passes through. The `fn`, Caps Lock and numeric-pad flags are masked out, so a plain fn+F1 still
adjusts brightness. A key up is consumed only if its key down was, so an app that received a
passed-through key down always receives the matching key up.

## Tests

New `DynamicNotchTests/Features/HUD/`: the interception matrix, plus real system-defined
`CGEvent`s driven through `SystemMediaKeyTap.handleEvent` (made internal to be reachable from
tests).
